### PR TITLE
Downloading client

### DIFF
--- a/Components/CurrentOnline.xaml.cs
+++ b/Components/CurrentOnline.xaml.cs
@@ -5,6 +5,7 @@ using System.Windows.Controls;
 using System.Windows.Threading;
 using NobleLauncher.Models;
 using NobleLauncher.Globals;
+using NobleLauncher.Structures;
 
 namespace NobleLauncher.Components
 {
@@ -16,7 +17,8 @@ namespace NobleLauncher.Components
         private readonly SiteAPIModel SiteAPI = SiteAPIModel.Instance();
         public CurrentOnline() {
             InitializeComponent();
-            Task.Run(() => DrawCurrentOnline());
+
+            EventDispatcher.CreateSubscription(EventDispatcherEvent.CompletePreload, () => Task.Run(() => DrawCurrentOnline()));
         }
         private void OpenCurrentOnlineLink(object sender, System.Windows.Input.MouseButtonEventArgs e) {
             Static.OpenLinkFromTag(sender, e);

--- a/Components/CustomPatches.xaml.cs
+++ b/Components/CustomPatches.xaml.cs
@@ -15,8 +15,11 @@ namespace NobleLauncher.Components
         private readonly UpdateServerAPIModel UpdateServerAPI = UpdateServerAPIModel.Instance();
         public CustomPatches() {
             InitializeComponent();
-            Task.Run(() => GetAndDrawCustomPatches());
-            Task.Run(() => GetAndDrawBasePatches());
+
+            EventDispatcher.CreateSubscription(EventDispatcherEvent.CompletePreload, () => {
+                Task.Run(() => GetAndDrawCustomPatches());
+                Task.Run(() => GetAndDrawBasePatches());
+            });
         }
 
         private void OpenPatchLink(object sender, MouseButtonEventArgs e) {

--- a/Components/CustomPatches.xaml.cs
+++ b/Components/CustomPatches.xaml.cs
@@ -16,9 +16,10 @@ namespace NobleLauncher.Components
         public CustomPatches() {
             InitializeComponent();
 
-            EventDispatcher.CreateSubscription(EventDispatcherEvent.CompletePreload, () => {
-                Task.Run(() => GetAndDrawCustomPatches());
-                Task.Run(() => GetAndDrawBasePatches());
+            EventDispatcher.CreateSubscription(EventDispatcherEvent.CompletePreload, async () => {
+                await Task.Run(() => GetAndDrawCustomPatches());
+                await Task.Run(() => GetAndDrawBasePatches());
+                EventDispatcher.Dispatch(EventDispatcherEvent.CompletePatchInfoRetrieving);
             });
         }
 

--- a/Components/Header.xaml
+++ b/Components/Header.xaml
@@ -25,7 +25,7 @@
         <TextBlock Grid.Column="2" Grid.ColumnSpan="2" Text="NOBLEGARDEN" FontSize="24" Foreground="#D8FAFAFA" FontFamily="Segoe UI Black" Margin="0,2,0,0" />
         <TextBlock Grid.Column="2" Text="Ролевой сервер World of Warcraft" FontFamily="Corbel" FontSize="14" Foreground="#D8FAFAFA" VerticalAlignment="Bottom" Margin="0,0,0,6"/>
         <Rectangle Fill="#59050505" Grid.Row="0" Grid.Column="2" RadiusY="16" RadiusX="16" Height="32" Margin="308,-18,138,41" Grid.ColumnSpan="2" />
-        <Image Name = "SettingsIcon" MouseDown="ToggleSettingsVisibility" Source="../Images/settings.png" Grid.Column="4" Width="24">
+        <Image Name = "SettingsIcon" MouseDown="ToggleSettingsVisibility" Source="../Images/settings.png" Grid.Column="4" Width="24" Visibility="Hidden">
             <Image.Style>
                 <Style TargetType="{x:Type Image}">
                     <Setter Property="Opacity" Value="0.6"/>

--- a/Components/Header.xaml.cs
+++ b/Components/Header.xaml.cs
@@ -12,10 +12,16 @@ namespace NobleLauncher.Components
     {
         public Header() {
             InitializeComponent();
+            EventDispatcher.CreateSubscription(EventDispatcherEvent.CompletePreload, () => SetSettingsButtonVisible());
             EventDispatcher.CreateSubscription(EventDispatcherEvent.StartUpdate, () => SetSettingsClickable(false));
             EventDispatcher.CreateSubscription(EventDispatcherEvent.CompleteUpdate, () => SetSettingsClickable(true));
         }
 
+        private void SetSettingsButtonVisible()
+        {
+            SettingsIcon.Visibility = Visibility.Visible;
+            SetSettingsClickable(true);
+        }
         private void ToggleSettingsVisibility(object sender, RoutedEventArgs e) {
             EventDispatcher.Dispatch(EventDispatcherEvent.SettingsButtonClick);
         }

--- a/Components/News.xaml.cs
+++ b/Components/News.xaml.cs
@@ -15,7 +15,7 @@ namespace NobleLauncher.Components
         private readonly SiteAPIModel SiteAPI = SiteAPIModel.Instance();
         public News() {
             InitializeComponent();
-            Task.Run(() => DrawLastNews());
+            EventDispatcher.CreateSubscription(EventDispatcherEvent.CompletePreload, () => Task.Run(() => DrawLastNews()));
         }
         private async Task DrawLastNews() {
             var newsResponse = await SiteAPI.GetLastNews();

--- a/Components/Preloader.xaml
+++ b/Components/Preloader.xaml
@@ -20,11 +20,12 @@
         <TextBlock
             Name="CurrentLoadingStepView"
             FontFamily="Bahnschrift Light"
-            FontSize="14"
+            FontSize="12"
             Text="Step"
             Foreground="#FFFAFAFA"
             HorizontalAlignment="Center"
-            VerticalAlignment="Center" Margin="300,352,298,230"
+            VerticalAlignment="Center"
+            Margin="0,352,0,230"
         />
         <ProgressBar
             Name="CurrentLoadingProgressView"
@@ -32,21 +33,59 @@
             Maximum="100"
             Height="8"
             Width="400"
-            Margin="0, 200, 0, 0"
+            Margin="0, 220, 0, 0"
             Background="#26E6E6E6"
             Foreground="#FF0B364F"
             BorderBrush="#26E6E6E6"
         />
+        <Border CornerRadius="4" BorderBrush="#AAFFFFFF" BorderThickness="2" Cursor="Hand">
+            <Rectangle
+                RadiusX="4"
+                RadiusY="4"
+                Name="DownloadClientButton"
+                Width="160"
+                Height="45"
+                Visibility="Hidden"
+                IsHitTestVisible="False"
+                MouseLeftButtonUp="DownloadClient"
+            >
+                <Rectangle.Style>
+                    <Style TargetType="{x:Type Rectangle}">
+                        <Setter Property="Fill" Value="#FF12161A"/>
+                        <Style.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter Property="Fill" Value="#FF090B0D"/>
+                            </Trigger>
+                        </Style.Triggers>
+                    </Style>
+                </Rectangle.Style>
+            </Rectangle>
+        </Border>
+        <TextBlock
+            Name="DownloadClientTextBlock"
+            HorizontalAlignment="Center"
+            VerticalAlignment="Center"
+            TextAlignment="Center"
+            Foreground="#FFFFFFFF"
+            FontFamily="Corbel"
+            IsHitTestVisible="False"
+            TextWrapping="WrapWithOverflow"
+            FontWeight="Bold"
+            FontSize="18"
+            Visibility="Hidden"
+        >
+            Скачать клиент
+        </TextBlock>
     </Grid>
     <UserControl.Resources>
         <Storyboard x:Key="FadeOutModalBG" Name="FadeOutModalAnimation">
             <DoubleAnimationUsingKeyFrames Storyboard.TargetName="ModalBackgroundView" Storyboard.TargetProperty="Opacity">
-                <LinearDoubleKeyFrame Value="1.0" KeyTime="00:00:00" />
-                <LinearDoubleKeyFrame Value="0.0" KeyTime="00:00:0.5" />
+                <LinearDoubleKeyFrame Value="1.0" KeyTime="00:00:00"/>
+                <LinearDoubleKeyFrame Value="0.0" KeyTime="00:00:0.5"/>
             </DoubleAnimationUsingKeyFrames>
             <BooleanAnimationUsingKeyFrames Storyboard.TargetName="ModalBackgroundRectangleView" Storyboard.TargetProperty="IsHitTestVisible">
-                <DiscreteBooleanKeyFrame Value="True" KeyTime="0:0:0" />
-                <DiscreteBooleanKeyFrame Value="False" KeyTime="0:0:0.5" />
+                <DiscreteBooleanKeyFrame Value="True" KeyTime="0:0:0"/>
+                <DiscreteBooleanKeyFrame Value="False" KeyTime="0:0:0.5"/>
             </BooleanAnimationUsingKeyFrames>
         </Storyboard>
     </UserControl.Resources>

--- a/Components/Preloader.xaml
+++ b/Components/Preloader.xaml
@@ -1,14 +1,15 @@
 ﻿<UserControl x:Class="NobleLauncher.Components.Preloader"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:gif="clr-namespace:XamlAnimatedGif;assembly=XamlAnimatedGif"
-             mc:Ignorable="d" 
+             mc:Ignorable="d"
              d:DesignHeight="600" d:DesignWidth="900">
     <Grid Name="ModalBackgroundView" Opacity="1">
-        <Rectangle Name="ModalBackgroundRectangleView" Fill="#FF062131" IsHitTestVisible="False"/>
+        <Rectangle Name="ModalBackgroundRectangleView" Fill="#FF062131" IsHitTestVisible="False" Margin="0,50,0,0"/>
         <Image
+            Name="LoadingAnimation"
             gif:AnimationBehavior.SourceUri="../Images/preloader.gif"
             Width="48" Height="48"
             HorizontalAlignment="Center"

--- a/Components/Preloader.xaml.cs
+++ b/Components/Preloader.xaml.cs
@@ -165,10 +165,10 @@ namespace NobleLauncher.Components
             File.Delete(client_archive_name);
         }
     
-        private int downloadedPatchesCount;
+        private int patchIndex;
         public Task DownloadInitialPatches()
         {
-            downloadedPatchesCount = 0;
+            patchIndex = 0;
             List<IUpdateable> missingPatches = Static.InitialPatches.List
                 .Where(patch => !File.Exists(patch.LocalPath))
                 .ToList();
@@ -182,10 +182,10 @@ namespace NobleLauncher.Components
                 },
                 (IUpdateable patch) =>
                 {
-                    downloadedPatchesCount++;
+                    patchIndex++;
                     Static.InUIThread(() =>
                     {
-                        CurrentLoadingStepView.Text = "Загрузка " + patch.LocalPath + "(" + (downloadedPatchesCount + 1) + "/" + missingPatches.Count + ")";
+                        CurrentLoadingStepView.Text = "Загрузка " + patch.LocalPath + "(" + patchIndex + "/" + missingPatches.Count + ")";
                     });
                 },
                 (loadedChunkSize, percentOfFile) =>

--- a/Components/Preloader.xaml.cs
+++ b/Components/Preloader.xaml.cs
@@ -1,8 +1,8 @@
-﻿using NobleLauncher.Globals;
+﻿using Newtonsoft.Json.Linq;
+using NobleLauncher.Globals;
 using NobleLauncher.Models;
 using NobleLauncher.Structures;
 using System;
-using System.Diagnostics;
 using System.IO;
 using System.Threading.Tasks;
 using System.Windows.Controls;
@@ -16,20 +16,120 @@ namespace NobleLauncher.Components
     public partial class Preloader : UserControl
     {
         private UpdateServerAPIModel UpdateServerAPI;
-
+        private bool triedToDownloadClient;
         public Preloader() {
             InitializeComponent();
+            triedToDownloadClient = false;
             EventDispatcher.CreateSubscription(EventDispatcherEvent.StartPreload, StartPreload);
         }
 
-        private async void StartPreload() {
+        private async void StartPreload()
+        {
             UpdateServerAPI = UpdateServerAPIModel.Instance();
             ModalBackgroundView.Opacity = 1;
-
             Migration();
-            await GetBasePatches();
-            PlaySuccessLoadAnimation();
-            EventDispatcher.Dispatch(EventDispatcherEvent.CompletePreload);
+
+            await GetClientFilesList();
+            bool clientIsOk = CheckIfClientFilesOk();
+            if (!clientIsOk && triedToDownloadClient)
+            {
+                ShowError("Что-то пошло не так. Обратитесь к разработчикам программы за помощью.");
+                return;
+            }
+
+            if (!clientIsOk)
+            {
+                ToggleLoadingAnimation(false);
+            }
+            if (clientIsOk)
+            {
+                await GetBasePatches();
+                PlaySuccessLoadAnimation();
+                EventDispatcher.Dispatch(EventDispatcherEvent.CompletePreload);
+            }
+        }
+
+        private bool CheckIfClientFilesOk()
+        {
+            if (!FastCheckClientExists())
+            {
+                if (!CheckDirectoryName())
+                {
+                    ShowError("Клиент не найден. Положите лаунчер в папку с именем Noblegarden и перезапустите.");
+                    return false;
+                }
+                ToggleDownloadButton(true);
+                return false;
+            }
+            return true;
+        }
+
+        private void ToggleLoadingAnimation(bool toggle)
+        {
+            LoadingAnimation.IsHitTestVisible = toggle;
+            LoadingAnimation.Visibility = toggle ? System.Windows.Visibility.Visible : System.Windows.Visibility.Hidden;
+        }
+        private void ToggleDownloadButton(bool toggle) {
+            DownloadClientButton.IsHitTestVisible = toggle;
+            DownloadClientButton.Visibility = toggle ? System.Windows.Visibility.Visible : System.Windows.Visibility.Hidden;
+            DownloadClientTextBlock.Visibility = toggle ? System.Windows.Visibility.Visible : System.Windows.Visibility.Hidden;
+            CurrentLoadingStepView.Visibility = toggle ? System.Windows.Visibility.Hidden : System.Windows.Visibility.Visible;
+        }
+
+        private void ShowError(string message)
+        {
+            Static.InUIThread(() => {
+                CurrentLoadingStepView.Text = message;
+            });
+        }
+
+        private bool CheckDirectoryName()
+        {
+            string currentDirectory = Directory.GetCurrentDirectory();
+            string folderName = new DirectoryInfo(currentDirectory).Name;
+            return folderName == "noblegarden" || folderName == "Noblegarden";
+        }
+
+        private bool FastCheckClientExists()
+        {
+            foreach (FileModel file in Static.ClientFiles)
+            {
+                if (!file.Exists()) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        private void RemoveClientFiles()
+        {
+            foreach (FileModel file in Static.ClientFiles)
+            {
+                if (file.Exists())
+                {
+                    file.Delete();
+                }
+            }
+            string interface_path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Interface");
+            Directory.Delete(interface_path, true);
+        }
+
+        public async void DownloadClient(object sender, System.Windows.Input.MouseButtonEventArgs e)
+        {
+            RemoveClientFiles();
+            string client_link = "http://31.129.44.181/noblegarden_client.zip";
+            string download_path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "noblegarden_client.zip");
+            if (!File.Exists(download_path))
+            {
+                await FileDownloader.DownloadFile(client_link, download_path, (chunkSize, percentage) =>
+                {
+                    CurrentLoadingProgressView.Value = percentage;
+                });
+            }
+            System.IO.Compression.ZipFile.ExtractToDirectory(download_path, AppDomain.CurrentDomain.BaseDirectory);
+            File.Delete(download_path);
+            triedToDownloadClient = true;
+            EventDispatcher.Dispatch(EventDispatcherEvent.StartPreload);
         }
 
         public void Migration() {
@@ -50,6 +150,16 @@ namespace NobleLauncher.Components
             var defaultPatches = JObjectConverter.ConvertToNecessaryPatchesList(patchesInfo);
             Static.Patches = new NoblePatchGroupModel<NecessaryPatchModel>(defaultPatches);
         }
+
+        private async Task GetClientFilesList()
+        {
+            CurrentLoadingStepView.Text = "Получаем список файлов клиента";
+            NobleResponse ClientFilesResponse = await UpdateServerAPI.GetClientFiles();
+            JObject filesInfo = ClientFilesResponse.FormattedData;
+            Static.ClientFiles = JObjectConverter.ConvertToClientFileList(filesInfo);
+            CurrentLoadingStepView.Text = "Cписок файлов клиента получен!";
+        }
+
         private void PlaySuccessLoadAnimation() {
             CurrentLoadingStepView.Text = "";
             var fadeOutAnim = (Storyboard)FindResource("FadeOutModalBG");

--- a/Components/Updater.xaml.cs
+++ b/Components/Updater.xaml.cs
@@ -62,8 +62,11 @@ namespace NobleLauncher.Components
         {
             foreach(IUpdateable patch in  patches)
             {
-                DateTime lastModified = await patch.GetRemoteLastModified();
-                File.SetLastWriteTime(patch.LocalPath, lastModified);
+                if (File.Exists(patch.LocalPath))
+                {
+                    DateTime lastModified = await patch.GetRemoteLastModified();
+                    File.SetLastWriteTime(patch.LocalPath, lastModified);
+                }
             }
         }
 

--- a/Components/Updater.xaml.cs
+++ b/Components/Updater.xaml.cs
@@ -114,7 +114,10 @@ namespace NobleLauncher.Components
         }
         private void CalcHash(IUpdateable patch)
         {
-            patch.LocalHash = patch.CalcCRC32Hash((blockSize) => {});
+            if (patch.RemoteHash != null)
+            {
+                patch.LocalHash = patch.CalcCRC32Hash((blockSize) => { });
+            }
         }
 
         private void UpdateProgressBar(int done, int total)

--- a/Components/Updater.xaml.cs
+++ b/Components/Updater.xaml.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Security.Policy;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Controls;
@@ -21,7 +20,7 @@ namespace NobleLauncher.Components
         public Updater()
         {
             InitializeComponent();
-            EventDispatcher.CreateSubscription(EventDispatcherEvent.CompletePreload, FastCheckUpdateNeeded);
+            EventDispatcher.CreateSubscription(EventDispatcherEvent.CompletePatchInfoRetrieving, FastCheckUpdateNeeded);
             EventDispatcher.CreateSubscription(EventDispatcherEvent.StartUpdate, Update);
         }
 

--- a/Components/Updater.xaml.cs
+++ b/Components/Updater.xaml.cs
@@ -184,44 +184,36 @@ namespace NobleLauncher.Components
             return summarySize;
         }
 
+        private int downloadedPatchesCount;
+        private long loadedSize;
+
         private Task DownloadFiles(List<IUpdateable> patches, long summarySize)
         {
-            if (patches.Count == 0)
-                return Task.Run(() => { });
-
-            long currentLoaded = 0;
-
-            Static.InUIThread(() => {
-                ActionTextView.Text = "Загружаем файлы";
-                SetProgress(0);
-            });
-
-            return Task.Run(async () => {
-                for (int i = 0; i < patches.Count; i++)
+            downloadedPatchesCount = 0;
+            loadedSize = 0;
+            return FileDownloader.DownloadFiles(patches, () =>
                 {
-                    var patch = patches[i];
-                    Static.InUIThread(() => {
-                        ActionTextView.Text = "Загружаем файл: " + patch.LocalPath + "(" + (i + 1) + "/" + patches.Count + ")";
-                    });
-
-                    await patch.LoadUpdated((loadedChunkSize, percentOfFile) => {
-                        currentLoaded += loadedChunkSize;
-                        double downloadProgress = (double)(currentLoaded) / (double)(summarySize);
-                        int progress = (int)(downloadProgress * 100);
-                        SetProgress(progress);
-                    });
-
-                    if (!File.Exists(patch.PathToTMP))
-                        return;
-
-                    if (File.Exists(patch.FullPath))
+                    Static.InUIThread(() =>
                     {
-                        File.Delete(patch.FullPath);
-                    }
-
-                    File.Move(patch.PathToTMP, patch.FullPath);
-                }
-            });
+                        ActionTextView.Text = "Загружаем файлы";
+                        SetProgress(0);
+                    });
+                },
+                (IUpdateable patch) =>
+                {
+                    downloadedPatchesCount++;
+                    Static.InUIThread(() =>
+                    {
+                        ActionTextView.Text = "Загружаем файл: " + patch.LocalPath + "(" + (downloadedPatchesCount + 1) + "/" + patches.Count + ")";
+                    });
+                },
+                (loadedChunkSize, percentOfFile) =>
+                {
+                    loadedSize += loadedChunkSize;
+                    double downloadProgress = (double)(loadedSize) / (double)(summarySize);
+                    int progress = (int)(downloadProgress * 100);
+                    SetProgress(progress);
+                });
         }
 
         private void CompleteUpdate()

--- a/Components/Updater.xaml.cs
+++ b/Components/Updater.xaml.cs
@@ -58,11 +58,33 @@ namespace NobleLauncher.Components
             });
         }
 
+        // https://stackoverflow.com/questions/876473/is-there-a-way-to-check-if-a-file-is-in-use
+        protected virtual bool CanWriteToFile(string path)
+        {
+            if (!File.Exists(path))
+            {
+                return false;
+            }
+            FileInfo file = new FileInfo(path);
+            try
+            {
+                using (FileStream stream = file.Open(FileMode.Open, FileAccess.Read, FileShare.None))
+                {
+                    stream.Close();
+                }
+            }
+            catch (IOException)
+            {
+                return false;
+            }
+            return true;
+        }
+
         private async Task UpdateLastModifiedTime(List<IUpdateable> patches)
         {
-            foreach(IUpdateable patch in  patches)
+            foreach (IUpdateable patch in patches)
             {
-                if (File.Exists(patch.LocalPath))
+                if (CanWriteToFile(patch.LocalPath))
                 {
                     DateTime lastModified = await patch.GetRemoteLastModified();
                     File.SetLastWriteTime(patch.LocalPath, lastModified);

--- a/Globals/Settings.cs
+++ b/Globals/Settings.cs
@@ -7,7 +7,7 @@ namespace NobleLauncher.Globals
     public static class Settings {
         public static readonly string WORKING_DIR = @".";
         public static readonly string NOBLE_DOMAIN = "https://noblegarden.net";
-        public static readonly string LAUNCHER_VERSION = "2.0.2";
+        public static readonly string LAUNCHER_VERSION = "2.0.3";
         public static bool ENABLE_TLS = false;
         public static bool ENABLE_DEBUG_MODE = false;
 

--- a/Globals/Static.cs
+++ b/Globals/Static.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Media.Imaging;
 using System.Windows.Threading;
+using NobleLauncher.Interfaces;
 using NobleLauncher.Models;
 using NobleLauncher.Structures;
 
@@ -14,6 +15,7 @@ namespace NobleLauncher.Globals
     public static class Static
     {
         public static DispatcherOperation CurrentUIOperation;
+        public static NoblePatchGroupModel<IUpdateable> InitialPatches;
         public static NoblePatchGroupModel<NecessaryPatchModel> Patches;
         public static NoblePatchGroupModel<CustomPatchModel> CustomPatches;
         public static List<FileModel> ClientFiles;

--- a/Globals/Static.cs
+++ b/Globals/Static.cs
@@ -16,6 +16,7 @@ namespace NobleLauncher.Globals
         public static DispatcherOperation CurrentUIOperation;
         public static NoblePatchGroupModel<NecessaryPatchModel> Patches;
         public static NoblePatchGroupModel<CustomPatchModel> CustomPatches;
+        public static List<FileModel> ClientFiles;
 
         public static readonly List<SliderElement> SliderElements = new List<SliderElement> {
             new SliderElement("Персонажи", "https://noblegarden.net/charlist", "Images/square-character.jpg"),

--- a/Interfaces/IUpdateable.cs
+++ b/Interfaces/IUpdateable.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 
 namespace NobleLauncher.Interfaces
 {
-    interface IUpdateable
+    public interface IUpdateable
     {
         string FullPath { get; }
         string LocalPath { get; set; }

--- a/Models/API/UpdateServerAPIModel.cs
+++ b/Models/API/UpdateServerAPIModel.cs
@@ -46,5 +46,15 @@ namespace NobleLauncher.Models
             }
             return response;
         }
+        public async Task<NobleResponse> GetClientFiles()
+        {
+            var response = await MakeAsyncRequest("/client_files.json");
+            if (!response.IsOK)
+            {
+                Static.ShutdownWithError("Не удалось получить данные о необходимых для клиента файлах.");
+                return new NobleResponse();
+            }
+            return response;
+        }
     }
 }

--- a/Models/API/UpdateServerAPIModel.cs
+++ b/Models/API/UpdateServerAPIModel.cs
@@ -32,7 +32,7 @@ namespace NobleLauncher.Models
         public async Task<NobleResponse> GetCustomPatches() {
             var response = await MakeAsyncRequest("/custom-patches.json");
             if (!response.IsOK) {
-                Static.ShutdownWithError("Не удалось получить данные о необязательных патчах");
+                Static.ShutdownWithError("Не удалось получить данные о необязательных патчах.");
                 return new NobleResponse();
             }
             return response;
@@ -41,7 +41,17 @@ namespace NobleLauncher.Models
         public async Task<NobleResponse> GetBasePatches() {
             var response = await MakeAsyncRequest("/patches.json");
             if (!response.IsOK) {
-                Static.ShutdownWithError("Не удалось получить данные об обязательных патчах");
+                Static.ShutdownWithError("Не удалось получить данные об обязательных патчах.");
+                return new NobleResponse();
+            }
+            return response;
+        }
+        public async Task<NobleResponse> GetInitialPatches()
+        {
+            var response = await MakeAsyncRequest("/initial_patches.json");
+            if (!response.IsOK)
+            {
+                Static.ShutdownWithError("Не удалось получить данные о базовых патчах.");
                 return new NobleResponse();
             }
             return response;

--- a/Models/Common/JObjectConverter.cs
+++ b/Models/Common/JObjectConverter.cs
@@ -114,6 +114,20 @@ namespace NobleLauncher.Models
             return new List<NecessaryPatchModel>(patches);
         }
 
+        public static List<PatchModel> ConvertToPatchesList(JObject Target)
+        {
+            var tokens = ConvertToTokenList(Target);
+            var patches = new PatchModel[tokens.Count];
+
+            Parallel.For(0, tokens.Count, (i) => {
+                patches[i] = ConvertTokenToPatch(tokens[i]);
+                patches[i].Index = i;
+            });
+
+            return new List<PatchModel>(patches);
+        }
+
+
         public static List<CustomPatchModel> ConvertToCustomPatchesList(JObject Target) {
             var tokens = ConvertToTokenList(Target);
             var patches = new CustomPatchModel[tokens.Count];

--- a/Models/Common/JObjectConverter.cs
+++ b/Models/Common/JObjectConverter.cs
@@ -65,6 +65,41 @@ namespace NobleLauncher.Models
             return patch;
         }
 
+        private static FileModel ConvertTokenToClientFile(JToken token)
+        {
+            FileModel file = new FileModel("");
+            var reader = new JTokenReader(token);
+            bool isObjectStarted = false;
+
+            while (reader.Read())
+            {
+                var tokenType = reader.TokenType;
+
+                if (tokenType == JsonToken.StartObject)
+                {
+                    isObjectStarted = true;
+                }
+
+                if (tokenType == JsonToken.PropertyName)
+                {
+                    string property = (string)reader.Value;
+
+                    if (isObjectStarted)
+                    {
+                        switch (property)
+                        {
+                            case "localpath":
+                                file.SetRelativePath(reader.ReadAsString());
+                                break;
+                            default:
+                                break;
+                        }
+                    }
+                }
+            }
+            return file;
+        }
+
         public static List<NecessaryPatchModel> ConvertToNecessaryPatchesList(JObject Target) {
             var tokens = ConvertToTokenList(Target);
             var patches = new NecessaryPatchModel[tokens.Count];
@@ -91,6 +126,19 @@ namespace NobleLauncher.Models
             });
 
             return new List<CustomPatchModel>(patches);
+        }
+
+        public static List<FileModel> ConvertToClientFileList(JObject Target)
+        {
+            var tokens = ConvertToTokenList(Target);
+            var files = new FileModel[tokens.Count];
+
+            Parallel.For(0, tokens.Count, (i) => {
+                FileModel file = ConvertTokenToClientFile(tokens[i]);
+                files[i] = file;
+            });
+
+            return new List<FileModel>(files);
         }
     }
 }

--- a/Models/Files/FileDownloader.cs
+++ b/Models/Files/FileDownloader.cs
@@ -1,5 +1,6 @@
 ﻿using NobleLauncher.Interfaces;
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
 using System.Net;
@@ -82,6 +83,37 @@ namespace NobleLauncher.Models
                 return;
 
             CurrentWebClient.CancelAsync();
+        }
+
+        public static Task DownloadFiles(List<IUpdateable> files,
+            Action OnStart,
+            Action<IUpdateable> OnNewFileDownload,
+            Action<long, int> OnLoadUpdated)
+        {
+            if (files.Count == 0)
+                return Task.Run(() => { });
+
+            OnStart();
+
+            return Task.Run(async () => {
+                for (int i = 0; i < files.Count; i++)
+                {
+                    var file = files[i];
+                    OnNewFileDownload(file);
+
+                    await file.LoadUpdated(OnLoadUpdated);
+
+                    if (!File.Exists(file.PathToTMP))
+                        return;
+
+                    if (File.Exists(file.FullPath))
+                    {
+                        File.Delete(file.FullPath);
+                    }
+
+                    File.Move(file.PathToTMP, file.FullPath);
+                }
+            });
         }
     }
 }

--- a/Models/Files/FileDownloader.cs
+++ b/Models/Files/FileDownloader.cs
@@ -36,12 +36,7 @@ namespace NobleLauncher.Models
         }
 
         public static void CreateFolderForDownload(string fileDestination) {
-            var dirPath = fileDestination;
-            var symb = dirPath[dirPath.Length - 1];
-            while (symb != '/') {
-                dirPath = dirPath.Substring(0, dirPath.Length - 1);
-                symb = dirPath[dirPath.Length - 1];
-            }
+            var dirPath = Path.GetDirectoryName(fileDestination);
 
             if (!Directory.Exists(dirPath)) {
                 Directory.CreateDirectory(dirPath);

--- a/Models/Files/FileModel.cs
+++ b/Models/Files/FileModel.cs
@@ -17,6 +17,13 @@ namespace NobleLauncher.Models
             );
         }
 
+        public void SetRelativePath(string RelativePath) {
+            PathToFile = Path.Combine(
+                    WORKING_DIR,
+                    RelativePath
+                );
+            }
+
         protected bool Exists() {
             return File.Exists(PathToFile);
         }

--- a/Models/Files/FileModel.cs
+++ b/Models/Files/FileModel.cs
@@ -24,7 +24,11 @@ namespace NobleLauncher.Models
                 );
             }
 
-        protected bool Exists() {
+        public void Delete()
+        {
+            File.Delete(PathToFile);
+        }
+        public bool Exists() {
             return File.Exists(PathToFile);
         }
 

--- a/Models/Patches/InitialPatchModel.cs
+++ b/Models/Patches/InitialPatchModel.cs
@@ -1,0 +1,27 @@
+﻿using NobleLauncher.Interfaces;
+
+namespace NobleLauncher.Models
+{
+    public class InitialPatchModel: PatchModel, IUpdateable
+    {
+        public InitialPatchModel(string LocalPath, string RemotePath, string Hash, string Description) : base(LocalPath, RemotePath, Hash, Description)
+        {
+            ChangeSelectionTo(true);
+        }
+
+        public override void ChangeSelectionTo(bool To)
+        {
+            Selected = true;
+        }
+
+        public override NecessaryPatchModel ToNecessaryPatch()
+        {
+            return new NecessaryPatchModel(LocalPath, RemotePath, RemoteHash, Description);
+        }
+
+        public override CustomPatchModel ToCustomPatchModel()
+        {
+            return new CustomPatchModel(LocalPath, RemotePath, RemoteHash, Description);
+        }
+    }
+}

--- a/Models/Patches/NoblePatchGroupModel.cs
+++ b/Models/Patches/NoblePatchGroupModel.cs
@@ -13,5 +13,7 @@ namespace NobleLauncher.Models
         public PatchType GetPatchByID(int id) {
             return List[id];
         }
+
+        public int Count() { return List.Count; }
     }
 }

--- a/NobleLauncher.csproj
+++ b/NobleLauncher.csproj
@@ -52,10 +52,10 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
+    <OutputPath>..\..\noblegarden\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+    <WarningLevel>3</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup>
@@ -71,13 +71,32 @@
     <GenerateManifests>true</GenerateManifests>
   </PropertyGroup>
   <PropertyGroup>
-    <SignManifests>true</SignManifests>
+    <SignManifests>false</SignManifests>
   </PropertyGroup>
   <PropertyGroup>
     <TargetZone>LocalIntranet</TargetZone>
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationIcon>logo-image.ico</ApplicationIcon>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x64\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <LangVersion>7.3</LangVersion>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <OutputPath>bin\x64\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <WarningLevel>3</WarningLevel>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <LangVersion>7.3</LangVersion>
+    <ErrorReport>prompt</ErrorReport>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Costura, Version=5.7.0.0, Culture=neutral, processorArchitecture=MSIL">
@@ -237,6 +256,9 @@
     <Compile Include="Components\Updater.xaml.cs">
       <DependentUpon>Updater.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Components\VersionUpdater.xaml.cs">
+      <DependentUpon>VersionUpdater.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Globals\Settings.cs" />
     <Compile Include="Interfaces\IUpdateable.cs" />
     <Compile Include="Models\Files\FileDownloader.cs" />
@@ -301,6 +323,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Components\Updater.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Components\VersionUpdater.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/Structures/EventDispatcherEvent.cs
+++ b/Structures/EventDispatcherEvent.cs
@@ -4,6 +4,7 @@
     {
         StartPreload,
         CompletePreload,
+        CompletePatchInfoRetrieving,
         SettingsButtonClick,
         SettingsRefresh,
         StartUpdate,


### PR DESCRIPTION
Also there were added client_files.json to the server with a list of client files. Except from Interface subfolder as it has a long list of files and even just a list of them would be big. It can be a problem in case if archive was corrupted somehow during downloading. But if we want to handle it - we need to calculate crc32 of files on every launcher run. I don't think it worth.

Added initial_patches.json to server.

So, overall algorithm is:

1. Get from server list of client files and patches to download.
2. If we have all of them - we can run the game.
3. If not - check the directory name. 
    - It has to be "noblegarden" to prevent users from downloading the client into their Downloads folder. 
    - I check it only after the listing files to not make users who have already installed their client into a different folder.
4. If the directory is right, enable "download" button.
5. It starts the download process. 
6. If there were no any client files - redownload client.
7. if there were no any patches - download missing patches.