### PR TITLE
Do not remove client files if not client found

### DIFF
--- a/Components/Header.xaml.cs
+++ b/Components/Header.xaml.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Input;
 
 namespace NobleLauncher.Components
 {
@@ -37,7 +38,10 @@ namespace NobleLauncher.Components
         }
 
         private void HandleDrag(object sender, System.Windows.Input.MouseEventArgs e) {
-            Application.Current.MainWindow.DragMove();
+            if (e.LeftButton == MouseButtonState.Pressed)
+            {
+                Application.Current.MainWindow.DragMove();
+            }
         }
     }
 }

--- a/Components/Preloader.xaml
+++ b/Components/Preloader.xaml
@@ -6,8 +6,8 @@
              xmlns:gif="clr-namespace:XamlAnimatedGif;assembly=XamlAnimatedGif"
              mc:Ignorable="d"
              d:DesignHeight="600" d:DesignWidth="900">
-    <Grid Name="ModalBackgroundView" Opacity="1">
-        <Rectangle Name="ModalBackgroundRectangleView" Fill="#FF062131" IsHitTestVisible="False" Margin="0,50,0,0"/>
+    <Grid Name="ModalBackgroundView" Opacity="1" IsHitTestVisible="True">
+        <Rectangle Name="ModalBackgroundRectangleView" Fill="#FF062131" Margin="0,50,0,0"/>
         <Image
             Name="LoadingAnimation"
             gif:AnimationBehavior.SourceUri="../Images/preloader.gif"
@@ -15,7 +15,6 @@
             HorizontalAlignment="Center"
             VerticalAlignment="Center"
             Panel.ZIndex="2"
-            IsHitTestVisible="False"
         />
         <TextBlock
             Name="CurrentLoadingStepView"
@@ -46,7 +45,6 @@
                 Width="160"
                 Height="45"
                 Visibility="Hidden"
-                IsHitTestVisible="False"
                 MouseLeftButtonUp="DownloadClient"
             >
                 <Rectangle.Style>
@@ -68,7 +66,6 @@
             TextAlignment="Center"
             Foreground="#FFFFFFFF"
             FontFamily="Corbel"
-            IsHitTestVisible="False"
             TextWrapping="WrapWithOverflow"
             FontWeight="Bold"
             FontSize="18"

--- a/Components/Preloader.xaml
+++ b/Components/Preloader.xaml
@@ -70,6 +70,7 @@
             FontWeight="Bold"
             FontSize="18"
             Visibility="Hidden"
+            IsHitTestVisible="False"
         >
             Скачать клиент
         </TextBlock>


### PR DESCRIPTION
Before this, if any of client files was not found, the launcher removed all the files and extracted the archive back, because in our .NET version there were no "extract with override" function by default. So used this implementation:
 https://discussions.unity.com/t/no-overwrite-option-in-zipfile-extracttodirectory-in-unity-2020-3-34f1-with-net-standard-2-0-extracttodirectory-with-overwrite-argument-not-available-in-unity/257622/2

Tested locally. It does override basic addons and so on, but doesn't remove the other ones.